### PR TITLE
Inactive users are not able to send and receive notifications on NodeBB side.

### DIFF
--- a/edx_notifications/server/api/api_utils.py
+++ b/edx_notifications/server/api/api_utils.py
@@ -44,7 +44,7 @@ class CustomTokenSessionAuthentication(BaseAuthentication):
         except User.DoesNotExist:
             return None
 
-        if not token == settings.NODEBB_MASTER_TOKEN or not user.is_active:
+        if not token == settings.NODEBB_MASTER_TOKEN:
             return None
 
         return (user, None)


### PR DESCRIPTION
Ticket no. [LP-2156](https://philanthropyu.atlassian.net/browse/LP-2156)

This PR has following tasks,
1. In order to bypass notifications for inactive user, removed inactive check from authentication.